### PR TITLE
Deployment Fixes

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   # Create release
   release:
-    needs: deploy
     runs-on: ubuntu-latest
     environment: build
 

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ test:
 
 .PHONY: docs
 docs:
-	pipenv run pdoc -d google -o docs --math nlca_pipelines nlca_pipelines.__main__
+	pipenv run pdoc -d google -o docs --math nlca_pipelines


### PR DESCRIPTION
## Info

* Remove dependency for `semantic-release` CI workflow, as it doesn't exist
* Simplify `make docs` command, ignoring the `__main__` file for now

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
