### PR TITLE
fix: checkout code before running semantic-release

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -16,6 +16,12 @@ jobs:
     environment: build
 
     steps:
+      # Checkout code
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       # Run Semantic Release to get versioning and changelog
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
## Info

* Checkout code before running `semantic-release`

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
