### PR TITLE
feat: Add validate decorator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ check_format:
 
 .PHONY: check_type
 check_type:
-	pipenv run python -m mypy nlca_pipelines
-	pipenv run python -m mypy tests
+	pipenv run python -m mypy nlca_pipelines --install-types --non-interactive
+	pipenv run python -m mypy tests --install-types --non-interactive
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -7,20 +7,27 @@ init:
 lint:
 	pipenv run pylint nlca_pipelines
 	pipenv run python -m flake8 nlca_pipelines
+	pipenv run pylint tests
+	pipenv run python -m flake8 tests
 
 .PHONY: check_format
 check_format:
 	pipenv run python -m isort nlca_pipelines --check-only
 	pipenv run python -m black nlca_pipelines --diff
+	pipenv run python -m isort tests --check-only
+	pipenv run python -m black tests --diff
 
 .PHONY: check_type
 check_type:
 	pipenv run python -m mypy nlca_pipelines
+	pipenv run python -m mypy tests
 
 .PHONY: format
 format:
 	pipenv run python -m isort nlca_pipelines
 	pipenv run python -m black nlca_pipelines --preview
+	pipenv run python -m isort tests
+	pipenv run python -m black tests --preview
 
 .PHONY: test
 test:

--- a/nlca_pipelines/validation/__init__.py
+++ b/nlca_pipelines/validation/__init__.py
@@ -1,3 +1,3 @@
-from .validate import validate
+from .validate import validate  # type: ignore
 
 __all__ = ["validate"]

--- a/nlca_pipelines/validation/__init__.py
+++ b/nlca_pipelines/validation/__init__.py
@@ -1,0 +1,3 @@
+from .validate import validate
+
+__all__ = ["validate"]

--- a/nlca_pipelines/validation/validate.py
+++ b/nlca_pipelines/validation/validate.py
@@ -1,0 +1,146 @@
+# type: ignore
+
+import logging
+from functools import wraps
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+)
+
+import pandas as pd
+
+logger = logging.getLogger()
+
+
+def validate(
+    required_cols: Optional[List[str]] = None, required_opts: Optional[List[str]] = None
+) -> Callable:
+    """Decorator to validate required cols and opts for class instance.
+
+    A method/function decorated with this decorator will validate that
+    the input dataframe has all the required columns to execute
+    successfully. It will also validate that the class instance has all
+    the required options set to execute successfully.
+
+    Args:
+        required_cols (Optional[List[str]]): List of required columns.
+        required_opts (Optional[List[str]]): List of required options.
+
+    Returns:
+        Callable: Decorator function.
+
+    Examples:
+        `validate` is a decorator that can be used to validate the input
+        dataframe before executing the decorated function. The decorator
+        can be used with or without required columns or options.
+        >>> class MyClass:
+        ...     @validate(required_cols=["age"])
+        ...     def func(self, df: pd.DataFrame) -> pd.DataFrame:
+        ...         df["age2"] = df["age"] + 2
+
+        If we pass in a dataframe that is missing a required column,
+        the function will raise a `ValueError`.
+        >>> df = pd.DataFrame({"name": ["Alice", "Bob"]})
+        >>> my_class = MyClass()
+        >>> my_class.func(df)
+        ValueError: Missing required columns: age
+
+        If we passin a dataframe that has the required column, the
+        function will execute successfully.
+        >>> df = pd.DataFrame({"name": ["Alice", "Bob"], "age": [5, 7]})
+        >>> my_class.func(df)
+            name    age     age2
+        0  Alice      5        7
+        1    Bob      7        9
+
+        The decorator preserves the `required_cols` and `required_opts`
+        arguments as attributes of the decorated function. This is
+        useful for documentation.
+        >>> getattr(my_class.func, "required_cols")
+        ['age']
+
+        Those attributes can also be accessed from the class, not just
+        the instance.
+        >>> getattr(MyClass.func, "required_cols")
+        ['age']
+
+    Notes:
+        Static methods and instance methods are supported. Class methods
+        are not supported at this time.
+    """
+
+    required_cols = required_cols or []
+    required_opts = required_opts or []
+
+    def inner(
+        func: Callable[[Any, pd.DataFrame], pd.DataFrame]
+    ) -> Callable[[Any, pd.DataFrame], pd.DataFrame]:
+        """Validates the input before calling the decorated function.
+
+        Args:
+            func (Callable): The function to be decorated.
+
+        Returns:
+            Callable: The decorated function.
+
+        Raises:
+            ValueError: If the input dataframe is missing any of the
+                required columns or options.
+        """
+        # expose the decorator args as attributes of the method
+        setattr(func, "required_cols", required_cols)
+        setattr(func, "required_opts", required_opts)
+
+        # wrap static methods
+        if isinstance(func, staticmethod):
+
+            @staticmethod
+            @wraps(func)
+            def wrapper(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
+                """Validate the input and execute the wrapped method.
+
+                Args:
+                    df (pd.DataFrame): Input dataframe to be validated.
+
+                Returns:
+                    pd.DataFrame: Validated dataframe.
+                """
+                if not all(col in df.columns for col in required_cols):
+                    missing: List[str] = list(set(required_cols) - set(df.columns))
+                    raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+                if required_opts:
+                    raise ValueError("Static methods cannot have `required_opts`.")
+
+                return func(df, *args, **kwargs)
+
+        # wrap instance methods
+        else:
+
+            @wraps(func)
+            def wrapper(self, df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
+                """Validate the input and execute the wrapped method.
+
+                Args:
+                    self: The instance of the class.
+                    df (pd.DataFrame): Input dataframe to be validated.
+
+                Returns:
+                    pd.DataFrame: Validated dataframe.
+                """
+                if not all(col in df.columns for col in required_cols):
+                    missing: List[str] = list(set(required_cols) - set(df.columns))
+                    raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+                if not all(opt in self.options for opt in required_opts):
+                    raise ValueError(
+                        f"Missing required options: {', '.join(required_opts)}"
+                    )
+
+                return func(df, *args, **kwargs)
+
+        return wrapper
+
+    return inner

--- a/nlca_pipelines/validation/validate.py
+++ b/nlca_pipelines/validation/validate.py
@@ -75,7 +75,7 @@ def validate(
     required_opts = required_opts or []
 
     def inner(
-        func: Callable[[Any, pd.DataFrame], pd.DataFrame]
+        func: Callable[[Any, pd.DataFrame], pd.DataFrame],
     ) -> Callable[[Any, pd.DataFrame], pd.DataFrame]:
         """Validates the input before calling the decorated function.
 

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -1,2 +1,0 @@
-def test_pass():
-    pass

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -1,0 +1,167 @@
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import pytest
+
+from nlca_pipelines.validation import validate
+
+
+@pytest.fixture
+def df() -> pd.DataFrame:
+    """Reusable dataframe as a fixture."""
+    return pd.DataFrame({"name": ["Alice", "Bob"], "age": [5, 7]})
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({}, id="no_args"),
+        pytest.param({"required_cols": ["a"]}, id="single-req-col"),
+        pytest.param({"required_cols": ["a", "b"]}, id="multi-req-cols"),
+        pytest.param({"required_opts": ["a"]}, id="single-req-opt"),
+        pytest.param({"required_opts": ["a", "b"]}, id="multi-req-opts"),
+        pytest.param({"required_cols": ["a"], "required_opts": ["b"]}, id="both"),
+    ],
+)
+def test_validate_decorator_preserves_args(kwargs: Dict[str, Any]) -> None:
+    """Variotions on valid kwargs passed to the validate decorator.
+
+    Args:
+        kwargs (Dict[str, Any]): Dictionary of keyword arguments to pass
+            to the decorator.
+    """
+
+    @validate(**kwargs)
+    def func(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+    
+    for key, value in kwargs.items():
+        assert getattr(func, key) == value
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"something_wrong": ["a"]}, id="single-wrong-kwarg"),
+        pytest.param(
+            {"required_cols": ["a"], "something_wrong": ["b"]},
+            id="single-right-single-wrong-kwargs",
+        ),
+        pytest.param(
+            {"something_wrong1": ["a"], "something_wrong2": ["b"]},
+            id="multi-wrong-kwargs",
+        ),
+    ],
+)
+def test_validate_decorator_raises_for_unexpected_args(kwargs: Dict[str, Any]) -> None:
+    """Variations on invalid kwargs passed to hte validate decorator.
+
+    Args:
+        kwargs (Dict[str, Any]): Dictionary of keyword arguments to pass
+            to the decorator.
+    """
+    with pytest.raises(TypeError):
+
+        @validate(**kwargs)
+        def _(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+
+def test_validate_decorator_raises_when_staticmethod_given_required_opts(
+    df: pd.DataFrame
+) -> None:
+    """Test that the validate decorator raises when required_opts are
+    given to a staticmethod.
+
+    The validate decorator should raise a ValueError when required_opts
+    are given to a staticmethod. This is because the options are stored
+    as an attribute of the instance and not the class; thereby, making
+    them unavailable to static methods.
+    """
+    class A:
+        @validate(required_opts=["a"])
+        @staticmethod
+        def func(df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+    with pytest.raises(ValueError) as exc_info:
+        A.func(df)
+
+    assert str(exc_info.value) == "Static methods cannot have `required_opts`."
+
+
+def test_validate_decorator_raises_when_instance_method_missing_required_cols(
+    df: pd.DataFrame
+) -> None:
+    """Test that the decorator raises for missing required columns.
+
+    Here, we test for instance methods. The decorator should raise a
+    ValueError when required columns are missing from the input
+    dataframe.
+    """
+    # pylint: disable=bad-staticmethod-argument,unused-argument
+    class A:
+        @validate(required_cols=["first_name"])
+        def func(self, df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+    # pylint: enable=bad-staticmethod-argument,unused-argument
+
+    with pytest.raises(ValueError) as exc_info:
+        # pylint: disable-next=no-value-for-parameter
+        A().func(df=df)
+
+    assert str(exc_info.value) == "Missing required columns: first_name"
+
+
+def test_validate_decorator_raises_when_static_method_missing_required_cols(
+    df: pd.DataFrame
+) -> None:
+    """Test that the decorator raises for missing required columns.
+
+    Here, we test for static methods. The decorator should raise a
+    ValueError when required columns are missing from the input
+    dataframe.
+    """
+    class A:
+        @validate(required_cols=["first_name"])
+        @staticmethod
+        def func(self, df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+    with pytest.raises(ValueError) as exc_info:
+        A().func(df=df)
+
+    assert str(exc_info.value) == "Missing required columns: first_name"
+
+
+def test_validate_decorator_raises_when_instance_method_missing_required_opts(
+    df: pd.DataFrame
+) -> None:
+    """Test that the validate decorator raises when required options are
+    missing.
+
+    The validate decorator should raise a ValueError when required
+    options are missing from the pipeline instance.
+    """
+    # pylint: disable=bad-staticmethod-argument,unused-argument
+    class A:
+        def __init__(
+            self,
+            steps: Optional[List[str]] = None,
+            options: Optional[Dict[str, Any]] = None,
+        ) -> None:
+            self.steps = steps
+            self.options = options
+
+        @validate(required_opts=["force_upper"])
+        def func(self, df: pd.DataFrame) -> pd.DataFrame:
+            return df
+
+    # pylint: enable=bad-staticmethod-argument,unused-argument
+
+    with pytest.raises(ValueError) as exc_info:
+        # pylint: disable-next=no-value-for-parameter
+        A(options={"other_option": "something"}).func(df=df)
+
+    assert str(exc_info.value) == "Missing required options: force_upper"

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -1,4 +1,12 @@
-from typing import Any, Dict, List, Optional
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-few-public-methods
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
 import pandas as pd
 import pytest
@@ -6,8 +14,8 @@ import pytest
 from nlca_pipelines.validation import validate
 
 
-@pytest.fixture
-def df() -> pd.DataFrame:
+@pytest.fixture(name="df")
+def fixture_df() -> pd.DataFrame:
     """Reusable dataframe as a fixture."""
     return pd.DataFrame({"name": ["Alice", "Bob"], "age": [5, 7]})
 
@@ -34,7 +42,7 @@ def test_validate_decorator_preserves_args(kwargs: Dict[str, Any]) -> None:
     @validate(**kwargs)
     def func(df: pd.DataFrame) -> pd.DataFrame:
         return df
-    
+
     for key, value in kwargs.items():
         assert getattr(func, key) == value
 
@@ -68,7 +76,7 @@ def test_validate_decorator_raises_for_unexpected_args(kwargs: Dict[str, Any]) -
 
 
 def test_validate_decorator_raises_when_staticmethod_given_required_opts(
-    df: pd.DataFrame
+    df: pd.DataFrame,
 ) -> None:
     """Test that the validate decorator raises when required_opts are
     given to a staticmethod.
@@ -78,6 +86,7 @@ def test_validate_decorator_raises_when_staticmethod_given_required_opts(
     as an attribute of the instance and not the class; thereby, making
     them unavailable to static methods.
     """
+
     class A:
         @validate(required_opts=["a"])
         @staticmethod
@@ -91,7 +100,7 @@ def test_validate_decorator_raises_when_staticmethod_given_required_opts(
 
 
 def test_validate_decorator_raises_when_instance_method_missing_required_cols(
-    df: pd.DataFrame
+    df: pd.DataFrame,
 ) -> None:
     """Test that the decorator raises for missing required columns.
 
@@ -99,6 +108,7 @@ def test_validate_decorator_raises_when_instance_method_missing_required_cols(
     ValueError when required columns are missing from the input
     dataframe.
     """
+
     # pylint: disable=bad-staticmethod-argument,unused-argument
     class A:
         @validate(required_cols=["first_name"])
@@ -115,7 +125,7 @@ def test_validate_decorator_raises_when_instance_method_missing_required_cols(
 
 
 def test_validate_decorator_raises_when_static_method_missing_required_cols(
-    df: pd.DataFrame
+    df: pd.DataFrame,
 ) -> None:
     """Test that the decorator raises for missing required columns.
 
@@ -123,11 +133,15 @@ def test_validate_decorator_raises_when_static_method_missing_required_cols(
     ValueError when required columns are missing from the input
     dataframe.
     """
+
+    # pylint: disable=bad-staticmethod-argument,unused-argument
     class A:
         @validate(required_cols=["first_name"])
         @staticmethod
-        def func(self, df: pd.DataFrame) -> pd.DataFrame:
+        def func(df: pd.DataFrame) -> pd.DataFrame:
             return df
+
+    # pylint: enable=bad-staticmethod-argument,unused-argument
 
     with pytest.raises(ValueError) as exc_info:
         A().func(df=df)
@@ -136,7 +150,7 @@ def test_validate_decorator_raises_when_static_method_missing_required_cols(
 
 
 def test_validate_decorator_raises_when_instance_method_missing_required_opts(
-    df: pd.DataFrame
+    df: pd.DataFrame,
 ) -> None:
     """Test that the validate decorator raises when required options are
     missing.
@@ -144,6 +158,7 @@ def test_validate_decorator_raises_when_instance_method_missing_required_opts(
     The validate decorator should raise a ValueError when required
     options are missing from the pipeline instance.
     """
+
     # pylint: disable=bad-staticmethod-argument,unused-argument
     class A:
         def __init__(


### PR DESCRIPTION
## Info

* Add a decorator called `validate` that will validate that a pipeline instance (to be developed) is in the correct state to execute, and fails gracefully if it isn't
* Small bug fixes and improvements

## References

* N/A

## Developer Checklist

- [x] Linting has been locally completed on the code
- [x] Formatting has been locally completed on the code
- [x] Type-checking has been locally completed on the code
- [x] Unit testing has been locally completed on the code
